### PR TITLE
Fix new_scaling_bloom

### DIFF
--- a/src/redablooms.c
+++ b/src/redablooms.c
@@ -604,7 +604,10 @@ scaling_bloom_t *new_scaling_bloom(unsigned int capacity, double error_rate,
     free_scaling_bloom(bloom);
     return NULL;
   }
-
+  
+  cur_bloom->header->id = 0;
+  cur_bloom->header->count = 0;
+  
   return bloom;
 }
 


### PR DESCRIPTION
new_scaling_bloom does not initialize value for header->id and header->count. 
In my environment, default value of id and count are not 0 so it run incorrect
